### PR TITLE
Add use warnings; to all files where it was not already enabled

### DIFF
--- a/lib/CGI/Test/Form.pm
+++ b/lib/CGI/Test/Form.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form;
 use strict;
+use warnings; 
 ####################################################################
 # $Id: Form.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Group.pm
+++ b/lib/CGI/Test/Form/Group.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Group;
 use strict;
+use warnings;
 ################################################################
 # $Id: Group.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget.pm
+++ b/lib/CGI/Test/Form/Widget.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget;
 use strict;
+use warnings;
 ################################################################
 # $Id: Widget.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Box.pm
+++ b/lib/CGI/Test/Form/Widget/Box.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Box;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Box.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Box/Check.pm
+++ b/lib/CGI/Test/Form/Widget/Box/Check.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Box::Check;
 use strict;
+use warnings;
 ##################################################################
 # $Id: Check.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Box/Radio.pm
+++ b/lib/CGI/Test/Form/Widget/Box/Radio.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Box::Radio;
 use strict;
+use warnings;
 ##################################################################
 # $Id: Radio.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Button.pm
+++ b/lib/CGI/Test/Form/Widget/Button.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Button;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Button.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Button/Image.pm
+++ b/lib/CGI/Test/Form/Widget/Button/Image.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Button::Image;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Image.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Button/Plain.pm
+++ b/lib/CGI/Test/Form/Widget/Button/Plain.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Button::Plain;
 use strict;
+use warnings;
 ##################################################################
 # $Id: Plain.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Button/Reset.pm
+++ b/lib/CGI/Test/Form/Widget/Button/Reset.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Button::Reset;
 use strict;
+use warnings;
 ##################################################################
 # $Id: Reset.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Button/Submit.pm
+++ b/lib/CGI/Test/Form/Widget/Button/Submit.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Button::Submit;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Submit.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Hidden.pm
+++ b/lib/CGI/Test/Form/Widget/Hidden.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Hidden;
 use strict;
+use warnings;
 ##################################################################
 # $Id: Hidden.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Input.pm
+++ b/lib/CGI/Test/Form/Widget/Input.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Input;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Input.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Input/File.pm
+++ b/lib/CGI/Test/Form/Widget/Input/File.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Input::File;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: File.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Input/Password.pm
+++ b/lib/CGI/Test/Form/Widget/Input/Password.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Input::Password;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Password.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Input/Text_Area.pm
+++ b/lib/CGI/Test/Form/Widget/Input/Text_Area.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Input::Text_Area;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Text_Area.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Input/Text_Field.pm
+++ b/lib/CGI/Test/Form/Widget/Input/Text_Field.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Input::Text_Field;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Text_Field.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Menu.pm
+++ b/lib/CGI/Test/Form/Widget/Menu.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Menu;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Menu.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Menu/List.pm
+++ b/lib/CGI/Test/Form/Widget/Menu/List.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Menu::List;
 use strict;
+use warnings;
 ##################################################################
 # $Id: List.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Form/Widget/Menu/Popup.pm
+++ b/lib/CGI/Test/Form/Widget/Menu/Popup.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Form::Widget::Menu::Popup;
 use strict;
+use warnings; 
 ##################################################################
 # $Id: Popup.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Input/Multipart.pm
+++ b/lib/CGI/Test/Input/Multipart.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Input::Multipart;
 use strict;
+use warnings; 
 ####################################################################
 # $Id: Multipart.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Input/URL.pm
+++ b/lib/CGI/Test/Input/URL.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Input::URL;
 use strict;
+use warnings;
 ####################################################################
 # $Id: URL.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page.pm
+++ b/lib/CGI/Test/Page.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page;
 use strict;
+use warnings;
 ####################################################################
 # $Id: Page.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page/Error.pm
+++ b/lib/CGI/Test/Page/Error.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page::Error;
 use strict;
+use warnings; 
 ####################################################################
 # $Id: Error.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page/HTML.pm
+++ b/lib/CGI/Test/Page/HTML.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page::HTML;
 use strict;
+use warnings; 
 ####################################################################
 # $Id: HTML.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page/Other.pm
+++ b/lib/CGI/Test/Page/Other.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page::Other;
 use strict;
+use warnings;
 ####################################################################
 # $Id: Other.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page/Real.pm
+++ b/lib/CGI/Test/Page/Real.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page::Real;
 use strict;
+use warnings; 
 ####################################################################
 # $Id: Real.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/lib/CGI/Test/Page/Text.pm
+++ b/lib/CGI/Test/Page/Text.pm
@@ -1,5 +1,6 @@
 package CGI::Test::Page::Text;
 use strict;
+use warnings;
 ####################################################################
 # $Id: Text.pm 411 2011-09-26 11:19:30Z nohuhu@nohuhu.org $
 # $Name: cgi-test_0-104_t1 $

--- a/t/01_env.t
+++ b/t/01_env.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings; 
+
 use Config;
 use Test::More tests => 16;
 

--- a/t/02_parsing.t
+++ b/t/02_parsing.t
@@ -1,3 +1,6 @@
+use strict; 
+use warnings; 
+
 use Config;
 use URI;
 

--- a/t/03_get.t
+++ b/t/03_get.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings; 
+
 use Config;
 
 use Test::More tests => 14;

--- a/t/04_post.t
+++ b/t/04_post.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Config;
 
 use Test::More tests => 14;

--- a/t/05_play_get.t
+++ b/t/05_play_get.t
@@ -1,3 +1,6 @@
+use strict; 
+use warnings;
+
 use lib 't/lib';
 
 use browse;

--- a/t/06_play_post.t
+++ b/t/06_play_post.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings; 
+
 use lib 't/lib';
 
 use browse;

--- a/t/07_play_multi.t
+++ b/t/07_play_multi.t
@@ -1,3 +1,6 @@
+use strict; 
+use warnings; 
+
 use lib 't/lib';
 
 use browse;

--- a/t/pod.t
+++ b/t/pod.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings; 
+
 use Test::More;
 
 if ( $ENV{POD_TESTS} ) {


### PR DESCRIPTION
The kwalitee score(http://cpants.cpanauthors.org/dist/CGI-Test) for this distribution is being affected by not having warnings enabled. This patch enables warnings where they were not previously enabled. All tests still pass with warnings enabled.