### PR TITLE
Added license heading to lib/CGI/Test.pm

### DIFF
--- a/lib/CGI/Test.pm
+++ b/lib/CGI/Test.pm
@@ -1160,6 +1160,12 @@ Steven Hilton was long time maintainer of this module.
 
 Current maintainer is Alex Tokarev F<E<lt>tokarev@cpan.orgE<gt>>.
 
+=head1 LICENSE
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the Artistic License, a copy of which can be
+found with perl.
+
 =head1 SEE ALSO
 
 CGI(3), CGI::Test::Page(3), CGI::Test::Form(3), CGI::Test::Input(3),


### PR DESCRIPTION
The absence of a LICENSE heading in the main module documentation was affecting this distribution's kwalitee score (http://cpants.cpanauthors.org/dist/CGI-Test).