### PR TITLE
accept https base URL

### DIFF
--- a/lib/CGI/Test.pm
+++ b/lib/CGI/Test.pm
@@ -52,7 +52,7 @@ sub new
 
     my $uri = URI->new($ubase);
     croak "-base_url $ubase is not within the http scheme"
-        unless $uri->scheme eq 'http';
+        unless ( $uri->scheme eq 'http' || $uri->scheme eq 'https' );
 
     my ($server, $path) = $this->split_uri($uri);
     $this->{host_port} = $server;


### PR DESCRIPTION
AFAIK the module shouldn't really care about the scheme, host or port, it's just using the base_url so we can copy-paste URLs from the browser into our tests; so https should be OK as well.
